### PR TITLE
Posting tweets by Cmd+Enter (Ctrl+Enter)

### DIFF
--- a/app/components/Modules/App/App.js
+++ b/app/components/Modules/App/App.js
@@ -1,9 +1,18 @@
 import React, { Component } from 'react';
+import { ShortcutManager } from 'react-shortcuts';
 import Navigation from '../../Molecules/Navigation/Navigation';
 import PostForm from '../../../containers/Molecules/PostForm';
 import styles from './app.css';
+import keymap from '../../../keymap';
+
+
+const shortcutManager = new ShortcutManager(keymap);
 
 export default class App extends Component {
+  getChildContext() {
+    return { shortcuts: shortcutManager };
+  }
+
   componentDidMount() {
     this.props.requestStreamUser();
   }
@@ -22,3 +31,7 @@ export default class App extends Component {
     );
   }
 }
+
+App.childContextTypes = {
+  shortcuts: React.PropTypes.object.isRequired
+};

--- a/app/components/Molecules/PostForm/PostForm.js
+++ b/app/components/Molecules/PostForm/PostForm.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Shortcuts } from 'react-shortcuts';
 import Textarea from '../../Atoms/Textarea/Textarea';
 import RemainingCharacters from '../../Atoms/RemainingCharacters/RemainingCharacters';
 import Button from '../../Atoms/Button/Button';
@@ -6,7 +7,19 @@ import styles from './postForm.css';
 
 export default ({ data = {}, inputUpdate, requestPostUpdate }) => (
   <form className={styles.postForm}>
-    <Textarea value={data.update} inputUpdate={inputUpdate} />
+    <Shortcuts
+      name="POSTFORM" handler={(action) => {
+        switch (action) {
+          case 'POST':
+            requestPostUpdate(data.update);
+            break;
+          default:
+            break;
+        }
+      }}
+    >
+      <Textarea value={data.update} inputUpdate={inputUpdate} />
+    </Shortcuts>
     <div className={styles.actions}>
       <RemainingCharacters remainingCharacters={data.remainingCharacters} />
       <span className={styles.button}>

--- a/app/components/Molecules/PostForm/PostForm.js
+++ b/app/components/Molecules/PostForm/PostForm.js
@@ -5,13 +5,23 @@ import RemainingCharacters from '../../Atoms/RemainingCharacters/RemainingCharac
 import Button from '../../Atoms/Button/Button';
 import styles from './postForm.css';
 
+function readyToPost(data) {
+  return (
+    !data.postingUpdate &&
+    data.remainingCharacters >= 0 &&
+    data.remainingCharacters < 140
+  );
+}
+
 export default ({ data = {}, inputUpdate, requestPostUpdate }) => (
   <form className={styles.postForm}>
     <Shortcuts
       name="POSTFORM" handler={(action) => {
         switch (action) {
           case 'POST':
-            requestPostUpdate(data.update);
+            if (readyToPost(data)) {
+              requestPostUpdate(data.update);
+            }
             break;
           default:
             break;
@@ -27,7 +37,7 @@ export default ({ data = {}, inputUpdate, requestPostUpdate }) => (
           type="normal"
           value="Post"
           onClick={() => requestPostUpdate(data.update)}
-          disabled={data.postingUpdate || data.remainingCharacters === 140 || data.remainingCharacters < 0}
+          disabled={!readyToPost(data)}
         />
       </span>
     </div>

--- a/app/keymap.js
+++ b/app/keymap.js
@@ -1,0 +1,9 @@
+export default {
+  POSTFORM: {
+    POST: {
+      osx: 'command+enter',
+      windows: 'ctrl+enter',
+      linux: 'ctrl+enter',
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^15.1.0",
     "react-redux": "^4.4.5",
     "react-router": "^2.4.1",
+    "react-shortcuts": "^1.3.1",
     "redux": "^3.5.2",
     "redux-actions": "^0.10.1",
     "redux-logger": "^2.6.1",


### PR DESCRIPTION
dependency として [react-shortcuts](https://github.com/avocode/react-shortcuts) を導入し、
PostForm の Textarea にフォーカスがある際に Cmd+Enter (Windows, LinuxではCtrl+Enter) で
ツイートを送信できるようにしました。